### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-
+## [0.1.23] - TBR.10.2025
+### Changed
+- Images automatically refresh when setting has been saved in the parser. [#23](https://github.com/JoelHer/Oculex/issues/23) ([6bd9d8b](https://github.com/JoelHer/Oculex/commit/6bd9d8b87f1aa1913d2ce7c1d47a07397166b7a4))
+- Box IDs are now based on total number of boxes ([03e64b6](https://github.com/JoelHer/Oculex/commit/03e64b6ce4b234b428ec542cfed001be2973cc97))
 
 ## [0.1.22] - 3.10.2025
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## [0.1.23] - TBR.10.2025
+## [0.1.23] - 4.10.2025
 ### Changed
 - Images automatically refresh when setting has been saved in the parser. [#23](https://github.com/JoelHer/Oculex/issues/23) ([6bd9d8b](https://github.com/JoelHer/Oculex/commit/6bd9d8b87f1aa1913d2ce7c1d47a07397166b7a4))
 - Box IDs are now based on total number of boxes ([03e64b6](https://github.com/JoelHer/Oculex/commit/03e64b6ce4b234b428ec542cfed001be2973cc97))
+- Disabled frame grabbing caching for now, due to bug ([2fc46f8](https://github.com/JoelHer/Oculex/commit/2fc46f8dabb98be01d6210136a3ba5513cc6888f))
 
 ## [0.1.22] - 3.10.2025
 ### Fixed

--- a/backend/StreamHandler.py
+++ b/backend/StreamHandler.py
@@ -149,9 +149,10 @@ class StreamHandler:
                 and not bustCache
             ):
                 current_time = time.time()
-                if current_time - self.lastFrameTimestamp < 60: # CACHE 60 SECONDS
-                    print(f"[StreamHandler] Returning cached frame for {url}")
-                    return self.lastFrame
+                # COMMENTED OUT FOR NOW BECAUSE OF ISSUES
+                #if current_time - self.lastFrameTimestamp < 60: # CACHE 60 SECONDS
+                #    print(f"[StreamHandler] Returning cached frame for {url}, age: {current_time - self.lastFrameTimestamp:.2f} seconds")
+                #    return self.lastFrame
 
             frame_data = None
 

--- a/frontend-vue/src/components/StreamEditor-Components/StreamEditor-parser.vue
+++ b/frontend-vue/src/components/StreamEditor-Components/StreamEditor-parser.vue
@@ -54,6 +54,7 @@ function saveImageSettings() {
     })
   }).then(() => {
     resetImageSettingsDirty()
+    reloadImage('both')
   })
 }
 
@@ -216,7 +217,8 @@ function updateSelectionStyle() {
 }
 function addBox() {
   if (selection.style.display === 'block') {
-    const newId = Date.now()
+    // short integer, based on the Nth box added
+    const newId = boxes.value.length > 0 ? Math.max(...boxes.value.map(b => b.id)) + 1 : 1
     // Save true image pixel coordinates
     const x = Math.min(selection.startX, selection.endX)
     const y = Math.min(selection.startY, selection.endY)
@@ -286,6 +288,8 @@ async function saveBoxes() {
       box_width: b.width,
       box_height: b.height
     })))
+  }).then(() => {
+    reloadImage('both')
   })
 }
 async function saveSettings() {
@@ -298,6 +302,8 @@ async function saveSettings() {
       crop_left: crop_left.value,
       crop_right: crop_right.value
     })
+  }).then(() => {
+    reloadImage('both')
   })
 }
 </script>

--- a/frontend/static/www/compiled/index.html
+++ b/frontend/static/www/compiled/index.html
@@ -9,8 +9,8 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Oculex</title>
-    <script type="module" crossorigin src="./assets/index-D1Jc_Fb_.js"></script>
-    <link rel="stylesheet" crossorigin href="./assets/index-BSG9X3Oz.css">
+    <script type="module" crossorigin src="./assets/index-BgyO8Fhx.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-DGSxIjeY.css">
   </head>
   <body>
     <div id="app" style="overflow: hidden;" style="height: 100vh;"></div>


### PR DESCRIPTION
This pull request introduces several improvements to the image refresh behavior and box ID assignment in the parser, as well as a temporary change to frame caching due to a bug. The main themes are image refresh consistency after saving settings, improved box ID logic, and disabling frame caching to address issues.

**Image refresh improvements:**
* Images now automatically refresh after saving image settings, box changes, or crop settings in `StreamEditor-parser.vue`, ensuring users see the latest updates without manual reloads. [[1]](diffhunk://#diff-ab7ac104b07ae49238b6d9e166b99bb188c7cb3bf86685988d12bcef52be6130R57) [[2]](diffhunk://#diff-ab7ac104b07ae49238b6d9e166b99bb188c7cb3bf86685988d12bcef52be6130R291-R292) [[3]](diffhunk://#diff-ab7ac104b07ae49238b6d9e166b99bb188c7cb3bf86685988d12bcef52be6130R305-R306)

**Box ID assignment logic:**
* Box IDs are now assigned based on the total number of boxes, using a sequential integer instead of relying on timestamps, which makes IDs more predictable and easier to manage.

**Frame caching changes:**
* Frame grabbing caching has been disabled in `StreamHandler.py` due to a bug, preventing potential issues with stale frames. The caching logic is commented out for now.

**Documentation and build updates:**
* The changelog (`CHANGELOG.md`) was updated to reflect these changes for version 0.1.23.
* Updated references to compiled frontend assets in `index.html` to ensure the latest build is loaded.